### PR TITLE
Add updateLogInData reducer to signInFormSlice

### DIFF
--- a/redux/features/signin-form/signinFormSlice.ts
+++ b/redux/features/signin-form/signinFormSlice.ts
@@ -12,7 +12,18 @@ const initialState: SignInFormState = {
 const signInFormSlice = createSlice({
 	name: "signin-form",
 	initialState,
-	reducers: {},
+	reducers: {
+		updateLogInData: (
+			state,
+			{ payload: { id, value } }: { payload: FormPayload }
+		) => ({
+			...state,
+			logInForm: {
+				...state.logInForm,
+				[id]: value,
+			},
+		}),
+	},
 });
 
 export default signInFormSlice.reducer;

--- a/types/redux-types.d.ts
+++ b/types/redux-types.d.ts
@@ -13,3 +13,8 @@ interface SignInFormState {
 	logInForm: LogInFormState;
 	registerForm: RegisterFormState;
 }
+
+interface FormPayload {
+	id: string;
+	value: string;
+}


### PR DESCRIPTION
1. Add **updateLogInData** reducer for updating logInForm state properties.
Function takes two parameters: **`state`** and **`payload`**. Function returns copied properties of the state and updates property with key `id` to value of variable `value`.
2. Add FormPayload interface to define payload type for the **updateLogInData** reducer.