### PR TITLE
Add LogInForm coponent

### DIFF
--- a/components/SignInForm/LogInForm/index.tsx
+++ b/components/SignInForm/LogInForm/index.tsx
@@ -1,0 +1,64 @@
+import { LOGINFORM_MSGs } from "@/constants";
+import { useAppSelector } from "@/redux/hooks";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { CustomLink, CustomTypography, ReqLabel } from "../CustomComponents";
+import styles from "../SignInForm.module.css";
+import SignInTemplate from "../Template";
+
+const LogInForm: React.FC = () => {
+	const { password, username } = useAppSelector(
+		(state) => state.signInForm.logInForm
+	);
+
+	return (
+		<>
+			<SignInTemplate
+				header={LOGINFORM_MSGs.head}
+				announcement={LOGINFORM_MSGs.msg}
+			>
+				<TextField
+					value={username}
+					type="text"
+					onChange={() => {}}
+					label={<ReqLabel text="Username" />}
+				/>
+				<TextField
+					value={password}
+					type="password"
+					onChange={() => {}}
+					label={<ReqLabel text="Password" />}
+				/>
+				<Typography>
+					Don't have an account?{" "}
+					<CustomTypography onClick={() => {}}>Sign Up</CustomTypography>
+				</Typography>
+				<CustomLink
+					href="/placeholder-accounts"
+					target="_blank"
+				>
+					List of placeholder accounts.
+				</CustomLink>
+			</SignInTemplate>
+			<Box className={styles.btnBox}>
+				<Button
+					type={"submit"}
+					variant="contained"
+					color="warning"
+					size="large"
+					sx={{
+						borderRadius: "var(--rounded-full)",
+						width: "100%",
+					}}
+				>
+					Log In
+				</Button>
+			</Box>
+		</>
+	);
+};
+
+export default LogInForm;


### PR DESCRIPTION
Create initial version of **LogInForm** component.
Features:
- Username and password input fields.
- Integrate Redux using useAppSelector to create controlled inputs.
- Style form using Material UI components & [custom components](https://github.com/AlzursThunder/reddit_clone/pull/44).
- Add link to list of [placeholder accounts](https://github.com/AlzursThunder/reddit_clone/pull/2)

#### Note:
TextField `onChange` & CustomTypography `onClick` props are left empty as placeholders for future implementation.