### PR TITLE
Initialize base version of two-step RegisterForm component

### DIFF
--- a/components/SignInForm/RegisterForm/index.tsx
+++ b/components/SignInForm/RegisterForm/index.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { REGISTERFORM_MSGs } from "@/constants";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+import { CustomFormButton } from "../CustomComponents";
+import styles from "../SignInForm.module.css";
+import SignInTemplate from "../Template";
+
+const RegisterForm: React.FC = () => {
+	const [currStep, setCurrStep] = useState<number>(0);
+
+	return (
+		<>
+			<SignInTemplate
+				header={REGISTERFORM_MSGs[currStep].head}
+				announcement={REGISTERFORM_MSGs[currStep].msg}
+			>
+				{currStep === 0 ? (
+					<>"First Step"</>
+				) : currStep === 1 ? (
+					<>"Second Step"</>
+				) : (
+					<span>Sorry something went wrong. Please try again.</span>
+				)}
+			</SignInTemplate>
+			<Stack
+				className={styles.btnBox}
+				direction={"row"}
+				gap={2}
+			>
+				{currStep !== 0 && (
+					<Tooltip title={"Back"}>
+						<IconButton
+							onClick={() => {
+								if (currStep > 0) setCurrStep((prev) => --prev);
+								return;
+							}}
+						>
+							<ArrowBackIcon />
+						</IconButton>
+					</Tooltip>
+				)}
+				<CustomFormButton
+					type={"button"}
+					variant="contained"
+					color="warning"
+					size="large"
+					onClick={async (ev) => {
+						try {
+							if (currStep !== 1) {
+								setCurrStep((prev) => ++prev);
+								return;
+							}
+						} catch (error) {
+							console.error(error);
+						}
+					}}
+				>
+					<Typography>{currStep === 1 ? "Sign Up" : "Next"}</Typography>
+				</CustomFormButton>
+			</Stack>
+		</>
+	);
+};
+
+export default RegisterForm;


### PR DESCRIPTION
Create initial version of RegisterForm component.
- Add state management for current step (`currStep`).
- Introduce two-step structure that utilizes `currStep` state:
    - Render form's step based on state value (line 22 - 28).
    - If step is bigger than 0 show arrow button, which lets user to come back to previous step (line 35 - 46).

### Notes:

1. CustomFormButton's onClick function (line 52) will be expanded in future commits.
2. Form steps will replace placeholder text (lines 23 & 25) in subsequent commits.