### PR TITLE
feat: Create second step for RegisterForm

### DIFF
--- a/components/SignInForm/RegisterForm/Step2.tsx
+++ b/components/SignInForm/RegisterForm/Step2.tsx
@@ -1,0 +1,31 @@
+import TextField from "@mui/material/TextField";
+import React from "react";
+import { ReqLabel } from "../CustomComponents";
+
+interface props {
+	username: string;
+	password: string;
+	handleChange: UpdateTextField;
+}
+
+const SecondeStep: React.FC<props> = ({ handleChange, password, username }) => {
+	return (
+		<>
+			<TextField
+				type="text"
+				label={<ReqLabel text="Username" />}
+				autoComplete="off"
+				value={username}
+				onChange={(ev) => handleChange(ev, "username")}
+			/>
+			<TextField
+				type={"password"}
+				label={<ReqLabel text="Password" />}
+				onChange={(ev) => handleChange(ev, "password")}
+				value={password}
+			/>
+		</>
+	);
+};
+
+export default SecondeStep;


### PR DESCRIPTION
Create **SecondStep** component for two-step RegisterForm.

#### Features:

- Controlled inputs for `username` & `password`.
- Custom component: **ReqLabel**.

Related pull requests:
- **RegisterForm**: #61.
- **ReqLabel** component: #44.