### PR TITLE
feat: Set up RegisterForm's validation

### DIFF
--- a/components/SignInForm/RegisterForm/index.tsx
+++ b/components/SignInForm/RegisterForm/index.tsx
@@ -2,12 +2,13 @@
 import { REGISTERFORM_MSGs } from "@/constants";
 import { updateRegisterData } from "@/redux/features/signin-form/signinFormSlice";
 import { useAppDispatch, useAppSelector } from "@/redux/hooks";
+import { validateRegisterData } from "@/utils";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { CustomFormButton, CustomTypography } from "../CustomComponents";
 import styles from "../SignInForm.module.css";
 import SignInTemplate from "../Template";
@@ -26,11 +27,27 @@ const RegisterForm: React.FC<props> = ({ setShowLoginForm }) => {
 
 	const [currStep, setCurrStep] = useState<number>(0);
 
+	const [isDataValid, setIsDataValid] = useState<boolean[]>([false, false]);
+
 	const handleChange: UpdateTextField = (ev, propertyId) => {
 		const { id, value } = ev.target;
 		dispatch(updateRegisterData({ id: propertyId ? propertyId : id, value }));
 		return;
 	};
+
+	useEffect(() => {
+		setIsDataValid((oldState) => {
+			const newState = [...oldState];
+
+			const isValidStep = validateRegisterData(
+				{ email, password, username },
+				currStep
+			);
+			newState[currStep] = isValidStep;
+
+			return newState;
+		});
+	}, [email, username, password]);
 
 	return (
 		<>
@@ -78,6 +95,7 @@ const RegisterForm: React.FC<props> = ({ setShowLoginForm }) => {
 					</Tooltip>
 				)}
 				<CustomFormButton
+					disabled={!isDataValid[currStep]}
 					type={"button"}
 					variant="contained"
 					color="warning"


### PR DESCRIPTION
### Features:

1. Add state `isDataValid` to keep track validity of form data (_line 30_).
2. Use `useEffect` hook to update state's element, indicated by `currStep` state (_line 28_), using **validateRegisterData** function.
3. Update button's disabled attribute to value from `isDataValid[currStep]` (_line 98_).

#### Related pull requests:

- **validateRegisterData** function: #70.