### PR TITLE
feat: Add feature for closing sign-in form after successfull registration

### DIFF
--- a/components/SignInForm/RegisterForm/index.tsx
+++ b/components/SignInForm/RegisterForm/index.tsx
@@ -28,6 +28,7 @@ import SecondStep from "./Step2";
 
 interface props {
 	setShowLoginForm: React.Dispatch<React.SetStateAction<boolean>>;
+	togglePanel: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 type ErrorMessagesState = {
@@ -41,7 +42,7 @@ const errorMessagesInitialState: ErrorMessagesState = {
 	basic: null,
 };
 
-const RegisterForm: React.FC<props> = ({ setShowLoginForm }) => {
+const RegisterForm: React.FC<props> = ({ setShowLoginForm, togglePanel }) => {
 	const dispatch = useAppDispatch();
 	const { email, username, password } = useAppSelector(
 		(state) => state.signInForm.registerForm
@@ -157,6 +158,7 @@ const RegisterForm: React.FC<props> = ({ setShowLoginForm }) => {
 							if (res.status === 200) {
 								setErrorMessages(errorMessagesInitialState);
 								setOpenSnackbar(true);
+								togglePanel(false)
 							}
 
 							batch(() => {

--- a/components/SignInForm/index.tsx
+++ b/components/SignInForm/index.tsx
@@ -48,7 +48,7 @@ const SignInForm: React.FC<props> = ({ togglePanel, openPanel }) => {
 						{showLoginForm ? (
 							<LogInForm setShowLoginForm={setShowLoginForm} />
 						) : (
-							<RegisterForm setShowLoginForm={setShowLoginForm} />
+							<RegisterForm setShowLoginForm={setShowLoginForm} togglePanel={togglePanel} />
 						)}
 					</form>
 				</ClickAwayListener>


### PR DESCRIPTION
### Features:

1. Add feature for closing sign-in form after user is successfully registered.
2. Expand RegisterForm's props with new property: `togglePanel`.


#### Related pull requests:
- **RegisterForm** component: #90.